### PR TITLE
Add basic FastAPI login API with device tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+app/users.db

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,33 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+SECRET_KEY = "change-me"  # In production, load from environment
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def decode_access_token(token: str) -> Optional[dict]:
+    try:
+        return jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    except JWTError:
+        return None

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,58 @@
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+DB_PATH = Path(__file__).resolve().parent / "users.db"
+
+
+def get_connection():
+    """Return a connection to the SQLite database."""
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def create_tables() -> None:
+    """Create required tables if they do not already exist."""
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS users (
+            username TEXT PRIMARY KEY,
+            hashed_password TEXT NOT NULL
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS logins (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT NOT NULL,
+            device_id TEXT NOT NULL,
+            login_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def get_user(username: str) -> Optional[sqlite3.Row]:
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM users WHERE username = ?", (username,))
+    user = cur.fetchone()
+    conn.close()
+    return user
+
+
+def add_login(username: str, device_id: str) -> None:
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO logins (username, device_id) VALUES (?, ?)",
+        (username, device_id),
+    )
+    conn.commit()
+    conn.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,59 @@
+from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from pydantic import BaseModel
+
+from . import auth, database
+
+app = FastAPI(title="Tradex Backend")
+
+database.create_tables()
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="login")
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+    device_id: str
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+@app.post("/login", response_model=Token)
+def login(data: LoginRequest):
+    user = database.get_user(data.username)
+    if not user or not auth.verify_password(data.password, user["hashed_password"]):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials",
+        )
+    database.add_login(data.username, data.device_id)
+    access_token = auth.create_access_token({"sub": data.username})
+    return Token(access_token=access_token)
+
+
+def get_current_user(token: str = Depends(oauth2_scheme)) -> str:
+    payload = auth.decode_access_token(token)
+    if payload is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        )
+    username = payload.get("sub")
+    if username is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        )
+    user = database.get_user(username)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found"
+        )
+    return username
+
+
+@app.get("/secure-data")
+def read_secure_data(current_user: str = Depends(get_current_user)):
+    return {"user": current_user, "message": "Secure content"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+passlib[bcrypt]
+python-jose

--- a/scripts/add_user.py
+++ b/scripts/add_user.py
@@ -1,0 +1,24 @@
+"""Utility to add a user with a hashed password."""
+from getpass import getpass
+
+from app import auth, database
+
+
+def main() -> None:
+    username = input("Username: ")
+    password = getpass("Password: ")
+    hashed = auth.get_password_hash(password)
+    conn = database.get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO users (username, hashed_password) VALUES (?, ?)",
+        (username, hashed),
+    )
+    conn.commit()
+    conn.close()
+    print(f"User {username} added")
+
+
+if __name__ == "__main__":
+    database.create_tables()
+    main()


### PR DESCRIPTION
## Summary
- scaffold FastAPI backend with JWT authentication
- store device IDs on each login in SQLite
- add utility script for creating users

## Testing
- `python -m py_compile app/*.py scripts/*.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac5f0c94a4832583fd8bf3e3813b88