### PR TITLE
Forward quote actions to OpenAI with message logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+last_openai_message.json


### PR DESCRIPTION
## Summary
- add optional `documents` support to quote requests
- centralize OpenAI forwarding and log sent messages to `last_openai_message.json`
- forward generate, patch, and PDF endpoints to OpenAI
- ignore cache files and logged messages

## Testing
- `python -m py_compile Presupost-main.py && echo 'py_compile success'`


------
https://chatgpt.com/codex/tasks/task_e_68ac5ff6d7648325b3c9ae9d4ded3389