### PR TITLE
Add device and time limits for demo accounts

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,0 +1,25 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+
+from . import auth, database
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="login")
+
+
+def get_current_user(token: str = Depends(oauth2_scheme)) -> str:
+    payload = auth.decode_access_token(token)
+    if payload is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        )
+    username = payload.get("sub")
+    if not username:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        )
+    user = database.get_user(username)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found"
+        )
+    return username


### PR DESCRIPTION
## Summary
- Track device usage and seed demo/demo2 accounts in the DB
- Require auth with device ID for quote generation
- Enforce 3-quote limit per device for demo and time-based access for demo2

## Testing
- `python -m py_compile app/database.py app/main.py app/quote.py app/dependencies.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68ac6980b9e883259f9e53d0e40c0aa8