### PR TITLE
Fix add_user script import path and bcrypt compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi
 uvicorn
-passlib[bcrypt]
+passlib[bcrypt]==1.7.4
+bcrypt<4
 python-jose

--- a/scripts/add_user.py
+++ b/scripts/add_user.py
@@ -1,5 +1,27 @@
 """Utility to add a user with a hashed password."""
 from getpass import getpass
+import sys
+from pathlib import Path
+
+# Add the project root to the Python path so ``app`` can be imported when the
+# script is executed directly (e.g. ``python scripts/add_user.py``).
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+# Work around incompatibility between ``passlib`` and ``bcrypt`` 4.x where the
+# latter removed ``__about__.__version__``.  ``passlib`` expects this attribute
+# and logs a traceback if it's missing.  Adding a minimal shim prevents the
+# spurious error without affecting functionality.
+try:  # pragma: no cover - defensive patch
+    import bcrypt as _bcrypt
+
+    if not hasattr(_bcrypt, "__about__"):
+        class _About:
+            __version__ = _bcrypt.__version__
+
+        _bcrypt.__about__ = _About()
+except Exception:  # pragma: no cover
+    pass
 
 from app import auth, database
 


### PR DESCRIPTION
## Summary
- ensure `scripts/add_user.py` can import the `app` package when run directly
- patch `bcrypt` so passlib doesn't log errors with version 4.x
- pin `passlib` and `bcrypt` versions for consistent installs

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement bcrypt<4)*
- `python scripts/add_user.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac68b52d088325af710da2d97803ec