### PR TITLE
Add Spanish prompt configuration message

### DIFF
--- a/app/quote.py
+++ b/app/quote.py
@@ -57,6 +57,7 @@ DB: dict[str, Quote] = {}
 # --- OpenAI ---
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 MODEL = os.getenv("MODEL_NAME", "gpt-4o-mini")  # ver doc oficial para modelos soportados
+PROMPT_FILE = os.path.join(os.path.dirname(__file__), "..", "aps", "prompt.txt")
 
 # --- Router ---
 router = APIRouter()
@@ -100,8 +101,14 @@ def parse_json(s: str) -> dict:
 @router.post("/api/quotes/generate", response_model=Quote)
 def generate(q: QuoteRequest, x_api_key: Optional[str] = Header(None)):
     check_api_key(x_api_key)
-    custom_msg = ("Eres un asistente que genera presupuestos técnicos cortos y claros "
-                  "para servicios de hogar/empresa en España. Devuelve SOLO JSON válido.")
+    try:
+        prompt_scope: dict[str, str] = {}
+        with open(PROMPT_FILE, "r", encoding="utf-8") as f:
+            exec(f.read(), {}, prompt_scope)
+        custom_msg = prompt_scope.get("custom_msg", "")
+    except FileNotFoundError:
+        raise HTTPException(500, "Prompt configuration file not found")
+
     completion = forward_to_openai(custom_msg, q.model_dump(), q.documents,
                                    response_format={"type": "json_object"})
     data = parse_json(completion.choices[0].message.content)

--- a/aps/prompt.txt
+++ b/aps/prompt.txt
@@ -1,0 +1,2 @@
+custom_msg = ("Eres un asistente que genera presupuestos técnicos cortos y claros "
+              "para servicios de hogar/empresa en España. Devuelve SOLO JSON válido.")


### PR DESCRIPTION
## Summary
- add prompt configuration message file with Spanish instructions
- load quote prompt from configuration file instead of hardcoded string

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac6b1d79f083258c67a126bb3f5e5f