### PR TITLE
Allow updating existing user passwords via add_user

### DIFF
--- a/scripts/add_user.py
+++ b/scripts/add_user.py
@@ -32,13 +32,22 @@ def main() -> None:
     hashed = auth.get_password_hash(password)
     conn = database.get_connection()
     cur = conn.cursor()
-    cur.execute(
-        "INSERT INTO users (username, hashed_password) VALUES (?, ?)",
-        (username, hashed),
-    )
+    cur.execute("SELECT 1 FROM users WHERE username = ?", (username,))
+    exists = cur.fetchone() is not None
+    if exists:
+        cur.execute(
+            "UPDATE users SET hashed_password = ? WHERE username = ?",
+            (hashed, username),
+        )
+        print(f"Password for {username} updated")
+    else:
+        cur.execute(
+            "INSERT INTO users (username, hashed_password) VALUES (?, ?)",
+            (username, hashed),
+        )
+        print(f"User {username} added")
     conn.commit()
     conn.close()
-    print(f"User {username} added")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Allow `scripts/add_user.py` to update the password of an existing user instead of failing on unique constraint

## Testing
- `python -m py_compile scripts/add_user.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac8aaa32408325815a6d96d95176e3