### PR TITLE
Add backend unit tests

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,32 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+
+import pytest
+from fastapi import HTTPException
+
+from app import auth, database
+from app.dependencies import get_current_user
+
+
+def test_password_hash_and_verify():
+    password = "secret"
+    hashed = auth.get_password_hash(password)
+    assert auth.verify_password(password, hashed)
+
+
+def test_create_and_decode_access_token():
+    token = auth.create_access_token({"sub": "user@example.com"})
+    decoded = auth.decode_access_token(token)
+    assert decoded["sub"] == "user@example.com"
+
+
+def test_get_current_user_with_valid_token():
+    database.create_tables()
+    token = auth.create_access_token({"sub": "demo@fixhub.es"})
+    user = get_current_user(token)
+    assert user == "demo@fixhub.es"
+
+
+def test_get_current_user_with_invalid_token():
+    with pytest.raises(HTTPException):
+        get_current_user("invalid.token")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,34 @@
+import sys, pathlib, sqlite3
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+
+import pytest
+from app import database
+
+
+def test_create_tables_seeds_demo_users(tmp_path, monkeypatch):
+    monkeypatch.setattr(database, 'DB_PATH', tmp_path / 'test.db')
+    database.create_tables()
+    user = database.get_user('demo@fixhub.es')
+    assert user is not None
+    assert user['username'] == 'demo@fixhub.es'
+
+
+def test_increment_device_usage(tmp_path, monkeypatch):
+    monkeypatch.setattr(database, 'DB_PATH', tmp_path / 'test.db')
+    database.create_tables()
+    database.increment_device_usage('demo@fixhub.es', 'device1')
+    database.increment_device_usage('demo@fixhub.es', 'device1')
+    usage = database.get_device_usage('demo@fixhub.es', 'device1')
+    assert usage['quote_count'] == 2
+
+
+def test_add_login_records_entry(tmp_path, monkeypatch):
+    monkeypatch.setattr(database, 'DB_PATH', tmp_path / 'test.db')
+    database.create_tables()
+    database.add_login('demo@fixhub.es', 'deviceA')
+    conn = database.get_connection()
+    cur = conn.cursor()
+    cur.execute('SELECT COUNT(*) FROM logins WHERE username=? AND device_id=?', ('demo@fixhub.es', 'deviceA'))
+    count = cur.fetchone()[0]
+    conn.close()
+    assert count == 1

--- a/tests/test_quote.py
+++ b/tests/test_quote.py
@@ -1,0 +1,94 @@
+import sys, pathlib, types, json
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+
+# Stub external modules not available in test environment
+class DummyOpenAI:
+    def __init__(self, *args, **kwargs):
+        pass
+
+openai_stub = types.SimpleNamespace(OpenAI=DummyOpenAI)
+sys.modules.setdefault('openai', openai_stub)
+
+class DummyTemplate:
+    def __init__(self, text):
+        self.text = text
+    def render(self, **kwargs):
+        return self.text
+
+class DummyEnvironment:
+    def __init__(self, loader=None):
+        pass
+    def from_string(self, text):
+        return DummyTemplate(text)
+
+class DummyBaseLoader:
+    pass
+
+sys.modules.setdefault('jinja2', types.SimpleNamespace(Environment=DummyEnvironment, BaseLoader=DummyBaseLoader))
+
+class DummyHTML:
+    def __init__(self, string):
+        self.string = string
+    def write_pdf(self):
+        return b'pdf'
+
+sys.modules.setdefault('weasyprint', types.SimpleNamespace(HTML=DummyHTML))
+
+from app import quote
+import pytest
+
+
+def fake_forward(custom_message, payload, documents=None, response_format=None):
+    data = {
+        'items': [{
+            'concept': 'Service',
+            'qty': 1,
+            'unit': 'u',
+            'unit_price': 100,
+            'subtotal': 100
+        }],
+        'tax_rate': 21,
+        'currency': 'EUR',
+        'terms': 'pay soon',
+        'note': 'thanks'
+    }
+    return types.SimpleNamespace(
+        choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=json.dumps(data)))]
+    )
+
+
+def setup_quote(monkeypatch, tmp_path):
+    quote.DB.clear()
+    monkeypatch.setattr(quote, 'forward_to_openai', fake_forward)
+    monkeypatch.setattr(quote, 'EXPECTED_API_KEY', None)
+    prompt_file = tmp_path / 'prompt.py'
+    prompt_file.write_text('custom_msg = "hi"')
+    monkeypatch.setattr(quote, 'PROMPT_FILE', str(prompt_file))
+
+
+def test_generate_quote(monkeypatch, tmp_path):
+    setup_quote(monkeypatch, tmp_path)
+    req = quote.QuoteRequest(client=quote.Client(name='John'), description='desc')
+    result = quote.generate(req, x_api_key=None, device_id='dev1', current_user='user@example.com')
+    assert result.quote_id == 'q_00001'
+    assert result.total == 121.0
+    assert result.quote_id in quote.DB
+
+
+def test_patch_quote(monkeypatch, tmp_path):
+    setup_quote(monkeypatch, tmp_path)
+    req = quote.QuoteRequest(client=quote.Client(name='John'), description='desc')
+    quote.generate(req, x_api_key=None, device_id='dev1', current_user='user@example.com')
+    body = quote.PatchBody(items=[quote.PatchItem(index=0, qty=2)])
+    patched = quote.patch_quote('q_00001', body, x_api_key=None)
+    assert patched.items[0].qty == 2
+    assert patched.total == 242.0
+
+
+def test_pdf_generation(monkeypatch, tmp_path):
+    setup_quote(monkeypatch, tmp_path)
+    req = quote.QuoteRequest(client=quote.Client(name='John'), description='desc')
+    quote.generate(req, x_api_key=None, device_id='dev1', current_user='user@example.com')
+    res = quote.pdf('q_00001', x_api_key=None)
+    assert res.media_type == 'application/pdf'
+    assert res.body == b'pdf'


### PR DESCRIPTION
## Summary
- add tests for database user seeding, device usage tracking, and login recording
- add tests for quote generation, editing, and PDF creation with mocked external services

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac8b7105ac83259852dbccb053593e