### PR TITLE
Add feature flags for optional modules

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,42 +1,73 @@
+"""Application entry point with optional modules.
+
+Environment variables control which features are enabled:
+
+```
+ENABLE_USER_AUTH  - user database and login endpoints (default: "1")
+ENABLE_INVOICE    - invoice routes (default: "1")
+ENABLE_QUOTE      - quote routes (default: "1")
+```
+"""
+
+import os
 from fastapi import Depends, FastAPI, HTTPException, status
 from pydantic import BaseModel
 
-from . import auth, database
-from .invoice import router as invoice_router
-from .quote import router as quote_router
-from .dependencies import get_current_user
+
+# ---------------------------------------------------------------------------
+# Feature flags
+# ---------------------------------------------------------------------------
+ENABLE_USER_AUTH = os.getenv("ENABLE_USER_AUTH", "1") == "1"
+ENABLE_INVOICE = os.getenv("ENABLE_INVOICE", "1") == "1"
+ENABLE_QUOTE = os.getenv("ENABLE_QUOTE", "1") == "1"
 
 app = FastAPI(title="Tradex Backend")
 
-database.create_tables()
-app.include_router(invoice_router, prefix="/facturas", tags=["facturas"])
-app.include_router(quote_router)
+
+# ---------------------------------------------------------------------------
+# Optional: user database and authentication
+# ---------------------------------------------------------------------------
+if ENABLE_USER_AUTH:
+    from . import auth, database
+    from .dependencies import get_current_user
+
+    database.create_tables()
+
+    class LoginRequest(BaseModel):
+        username: str
+        password: str
+        device_id: str
+
+    class Token(BaseModel):
+        access_token: str
+        token_type: str = "bearer"
+
+    @app.post("/login", response_model=Token)
+    def login(data: LoginRequest):
+        user = database.get_user(data.username)
+        if not user or not auth.verify_password(data.password, user["hashed_password"]):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid credentials",
+            )
+        database.add_login(data.username, data.device_id)
+        access_token = auth.create_access_token({"sub": data.username})
+        return Token(access_token=access_token)
+
+    @app.get("/secure-data")
+    def read_secure_data(current_user: str = Depends(get_current_user)):
+        return {"user": current_user, "message": "Secure content"}
 
 
-class LoginRequest(BaseModel):
-    username: str
-    password: str
-    device_id: str
+# ---------------------------------------------------------------------------
+# Optional: invoice and quote routers
+# ---------------------------------------------------------------------------
+if ENABLE_INVOICE:
+    from .invoice import router as invoice_router
 
+    app.include_router(invoice_router, prefix="/facturas", tags=["facturas"])
 
-class Token(BaseModel):
-    access_token: str
-    token_type: str = "bearer"
+if ENABLE_QUOTE:
+    from .quote import router as quote_router
 
-
-@app.post("/login", response_model=Token)
-def login(data: LoginRequest):
-    user = database.get_user(data.username)
-    if not user or not auth.verify_password(data.password, user["hashed_password"]):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid credentials",
-        )
-    database.add_login(data.username, data.device_id)
-    access_token = auth.create_access_token({"sub": data.username})
-    return Token(access_token=access_token)
-
-
-@app.get("/secure-data")
-def read_secure_data(current_user: str = Depends(get_current_user)):
-    return {"user": current_user, "message": "Secure content"}
+    app.include_router(quote_router)

--- a/app/quote.py
+++ b/app/quote.py
@@ -7,7 +7,17 @@ from openai import OpenAI
 from jinja2 import Environment, BaseLoader
 from weasyprint import HTML
 
-from .dependencies import get_current_user
+# ---------------------------------------------------------------------------
+# Optional authentication dependency
+# ---------------------------------------------------------------------------
+ENABLE_USER_AUTH = os.getenv("ENABLE_USER_AUTH", "1") == "1"
+if ENABLE_USER_AUTH:
+    from .dependencies import get_current_user
+else:  # pragma: no cover - simple fallback for unauthenticated mode
+    def get_current_user():  # type: ignore[override]
+        """Fallback dependency when authentication is disabled."""
+        return "anonymous"
+
 from . import database
 
 # --- Seguridad simple (demo) ---

--- a/tests/test_feature_toggles.py
+++ b/tests/test_feature_toggles.py
@@ -1,0 +1,36 @@
+import importlib
+import importlib.util
+import sys
+import pathlib
+import pytest
+
+# Ensure package import
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+
+
+def reload_app(monkeypatch, **envs):
+    for key, value in envs.items():
+        monkeypatch.setenv(key, value)
+    # Provide required secret for auth module even if unused
+    monkeypatch.setenv("SECRET_KEY", "testing")
+    import app.main
+    importlib.reload(app.main)
+    return app.main.app
+
+
+def test_quote_router_disabled(monkeypatch):
+    app = reload_app(monkeypatch, ENABLE_QUOTE="0", ENABLE_USER_AUTH="0", ENABLE_INVOICE="0")
+    paths = [route.path for route in app.routes]
+    assert "/api/status" not in paths
+
+
+@pytest.mark.skipif(importlib.util.find_spec("sqlalchemy") is None, reason="sqlalchemy not installed")
+def test_invoice_router_toggle(monkeypatch):
+    app_disabled = reload_app(monkeypatch, ENABLE_INVOICE="0", ENABLE_QUOTE="0", ENABLE_USER_AUTH="0")
+    paths_disabled = [route.path for route in app_disabled.routes]
+    assert not any(p.startswith("/facturas") for p in paths_disabled)
+
+    app_enabled = reload_app(monkeypatch, ENABLE_INVOICE="1", ENABLE_QUOTE="0", ENABLE_USER_AUTH="0")
+    paths_enabled = [route.path for route in app_enabled.routes]
+    assert any(p.startswith("/facturas") for p in paths_enabled)
+


### PR DESCRIPTION
## Summary
- allow enabling user auth, invoices, and quotes via environment variables
- permit quote service to run without authentication
- cover feature toggles with tests

## Testing
- `SECRET_KEY=testing pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acac184e4483259fa4742c21d937d4