### PR TITLE
Move status endpoint to main app

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,15 @@ app = FastAPI(title="Tradex Backend")
 
 
 # ---------------------------------------------------------------------------
+# Health check
+# ---------------------------------------------------------------------------
+@app.post("/api/status")
+def status():
+    """Simple endpoint to verify the service is running."""
+    return {"status": "alive"}
+
+
+# ---------------------------------------------------------------------------
 # Optional: user database and authentication
 # ---------------------------------------------------------------------------
 if ENABLE_USER_AUTH:

--- a/app/quote.py
+++ b/app/quote.py
@@ -75,12 +75,6 @@ PROMPT_FILE = os.path.join(os.path.dirname(__file__), "..", "aps", "prompt.txt")
 # --- Router ---
 router = APIRouter()
 
-# --- Health check ---
-@router.post("/api/status")
-def status():
-    """Simple endpoint to verify the service is running."""
-    return {"status": "alive"}
-
 # --- Utils ---
 def forward_to_openai(custom_message: str, payload: dict,
                       documents: Optional[List[str]] = None,

--- a/tests/test_feature_toggles.py
+++ b/tests/test_feature_toggles.py
@@ -21,7 +21,8 @@ def reload_app(monkeypatch, **envs):
 def test_quote_router_disabled(monkeypatch):
     app = reload_app(monkeypatch, ENABLE_QUOTE="0", ENABLE_USER_AUTH="0", ENABLE_INVOICE="0")
     paths = [route.path for route in app.routes]
-    assert "/api/status" not in paths
+    assert "/api/quotes/generate" not in paths
+    assert "/api/status" in paths
 
 
 @pytest.mark.skipif(importlib.util.find_spec("sqlalchemy") is None, reason="sqlalchemy not installed")


### PR DESCRIPTION
## Summary
- expose `/api/status` from the main application instead of the quote router
- adjust feature toggle test for quote router

## Testing
- `pytest -q` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68acb27a84288325874fc7ff50fb6f8d