### PR TITLE
Align login API with frontend format

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -3,7 +3,7 @@ from fastapi.security import OAuth2PasswordBearer
 
 from . import auth, database
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="login")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="api/auth/login")
 
 
 def get_current_user(token: str = Depends(oauth2_scheme)) -> str:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -30,3 +30,16 @@ def test_get_current_user_with_valid_token():
 def test_get_current_user_with_invalid_token():
     with pytest.raises(HTTPException):
         get_current_user("invalid.token")
+
+
+def test_login_endpoint(monkeypatch, tmp_path):
+    """Login should accept email/password and return a token."""
+    monkeypatch.setattr(database, 'DB_PATH', tmp_path / 'test.db')
+    database.create_tables()
+    monkeypatch.setenv("ENABLE_INVOICE", "0")
+    monkeypatch.setenv("ENABLE_QUOTE", "0")
+    from app.main import LoginRequest, login
+
+    req = LoginRequest(email="demo@fixhub.es", password="demo123!")
+    token = login(req)
+    assert token.token


### PR DESCRIPTION
## Summary
- Expose `/api/auth/login` that accepts email/password and returns a token
- Point OAuth2PasswordBearer to the new login route
- Test login flow directly via FastAPI function

## Testing
- `SECRET_KEY=secret pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68acbd8627248325b1ad1b1245ecd95d