### PR TITLE
Add CORS middleware to allow OPTIONS requests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ ENABLE_QUOTE      - quote routes (default: "1")
 
 import os
 from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 
@@ -22,6 +23,14 @@ ENABLE_INVOICE = os.getenv("ENABLE_INVOICE", "1") == "1"
 ENABLE_QUOTE = os.getenv("ENABLE_QUOTE", "1") == "1"
 
 app = FastAPI(title="Tradex Backend")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # or specific frontend URLs
+    allow_credentials=True,
+    allow_methods=["*"],  # ensures OPTIONS is permitted
+    allow_headers=["*"],
+)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add FastAPI CORSMiddleware to accept cross-origin requests and OPTIONS

## Testing
- `SECRET_KEY=test pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acc180ac708325bba45d31adf657c1