### PR TITLE
Expose user list endpoint for troubleshooting

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -74,6 +74,16 @@ def get_user(username: str) -> Optional[sqlite3.Row]:
     return user
 
 
+def get_all_users() -> list[dict]:
+    """Return all user records as a list of dictionaries."""
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM users")
+    rows = cur.fetchall()
+    conn.close()
+    return [dict(row) for row in rows]
+
+
 def add_login(username: str, device_id: str) -> None:
     conn = get_connection()
     cur = conn.cursor()

--- a/app/main.py
+++ b/app/main.py
@@ -71,6 +71,11 @@ if ENABLE_USER_AUTH:
         access_token = auth.create_access_token({"sub": data.email})
         return Token(token=access_token)
 
+    @app.get("/api/auth/users")
+    def list_users():
+        """Return all users for troubleshooting purposes."""
+        return database.get_all_users()
+
     @app.get("/secure-data")
     def read_secure_data(current_user: str = Depends(get_current_user)):
         return {"user": current_user, "message": "Secure content"}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -43,3 +43,16 @@ def test_login_endpoint(monkeypatch, tmp_path):
     req = LoginRequest(email="demo@fixhub.es", password="demo123!")
     token = login(req)
     assert token.token
+
+
+def test_list_users_endpoint(monkeypatch, tmp_path):
+    """The troubleshooting endpoint should list all users."""
+    monkeypatch.setattr(database, 'DB_PATH', tmp_path / 'test.db')
+    database.create_tables()
+    monkeypatch.setenv("ENABLE_INVOICE", "0")
+    monkeypatch.setenv("ENABLE_QUOTE", "0")
+    from app.main import list_users
+
+    users = list_users()
+    usernames = {u['username'] for u in users}
+    assert 'demo@fixhub.es' in usernames

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -13,6 +13,14 @@ def test_create_tables_seeds_demo_users(tmp_path, monkeypatch):
     assert user['username'] == 'demo@fixhub.es'
 
 
+def test_get_all_users_returns_seeded_accounts(tmp_path, monkeypatch):
+    monkeypatch.setattr(database, 'DB_PATH', tmp_path / 'test.db')
+    database.create_tables()
+    users = database.get_all_users()
+    usernames = {u['username'] for u in users}
+    assert {'demo@fixhub.es', 'demo2@fixhub.es'} <= usernames
+
+
 def test_increment_device_usage(tmp_path, monkeypatch):
     monkeypatch.setattr(database, 'DB_PATH', tmp_path / 'test.db')
     database.create_tables()


### PR DESCRIPTION
## Summary
- allow retrieving all users from the SQLite database
- add `/api/auth/users` endpoint for debugging login issues
- cover new functionality with tests

## Testing
- `SECRET_KEY=test pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acc76123c08325b77a58db39fadd01