### PR TITLE
feat: secure CORS and add CSRF protection

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,13 +1,17 @@
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer
 
 from . import auth, database
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="api/auth/login")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="api/auth/login", auto_error=False)
 
 
-def get_current_user(token: str = Depends(oauth2_scheme)) -> str:
-    payload = auth.decode_access_token(token)
+def get_current_user(
+    token: str = Depends(oauth2_scheme), request: Request = None
+) -> str:
+    if not token and request is not None:
+        token = request.cookies.get("auth_token")
+    payload = auth.decode_access_token(token) if token else None
     if payload is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"

--- a/app/main.py
+++ b/app/main.py
@@ -10,8 +10,10 @@ ENABLE_QUOTE      - quote routes (default: "1")
 """
 
 import os
-from fastapi import Depends, FastAPI, HTTPException, status
+import secrets
+from fastapi import Depends, FastAPI, HTTPException, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 
@@ -24,13 +26,41 @@ ENABLE_QUOTE = os.getenv("ENABLE_QUOTE", "1") == "1"
 
 app = FastAPI(title="Tradex Backend")
 
+# Restrict CORS to production and staging domains
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # or specific frontend URLs
+    allow_origins=["https://fixhub.opotek.es"],
+    allow_origin_regex=r"https://.*\.staging\.opotek\.es",
     allow_credentials=True,
     allow_methods=["*"],  # ensures OPTIONS is permitted
     allow_headers=["*"],
 )
+
+
+@app.middleware("http")
+async def add_security_headers(request: Request, call_next):
+    """Inject common security headers into every response."""
+    response = await call_next(request)
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["Referrer-Policy"] = "same-origin"
+    response.headers[
+        "Strict-Transport-Security"
+    ] = "max-age=63072000; includeSubDomains; preload"
+    return response
+
+
+@app.middleware("http")
+async def csrf_protect(request: Request, call_next):
+    """Simple double submit CSRF protection for cookie-based auth."""
+    if request.method not in ("GET", "HEAD", "OPTIONS"):
+        auth_cookie = request.cookies.get("auth_token")
+        if auth_cookie:
+            csrf_cookie = request.cookies.get("csrf_token")
+            csrf_header = request.headers.get("X-CSRF-Token")
+            if not csrf_cookie or csrf_header != csrf_cookie:
+                return Response(status_code=status.HTTP_403_FORBIDDEN)
+    return await call_next(request)
 
 
 # ---------------------------------------------------------------------------
@@ -69,7 +99,22 @@ if ENABLE_USER_AUTH:
         # Record the login with a generic device identifier
         database.add_login(data.email, "web")
         access_token = auth.create_access_token({"sub": data.email})
-        return Token(token=access_token)
+        csrf_token = secrets.token_urlsafe(16)
+        response = JSONResponse(content=Token(token=access_token).dict())
+        response.set_cookie(
+            "auth_token",
+            access_token,
+            httponly=True,
+            secure=True,
+            samesite="lax",
+        )
+        response.set_cookie(
+            "csrf_token",
+            csrf_token,
+            secure=True,
+            samesite="lax",
+        )
+        return response
 
 
     @app.get("/api/auth/users")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 passlib[bcrypt]==1.7.4
 bcrypt<4
 python-jose
+httpx

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,115 @@
+import sys, pathlib, json, asyncio, os
+from http.cookies import SimpleCookie
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+
+import pytest
+
+os.environ.setdefault("ENABLE_INVOICE", "0")
+os.environ.setdefault("ENABLE_QUOTE", "0")
+os.environ.setdefault("SECRET_KEY", "testsecret")
+
+from app.main import app, database
+
+
+async def asgi_request(app, method, path, headers=None, body=b""):
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "method": method,
+        "path": path,
+        "raw_path": path.encode(),
+        "scheme": "http",
+        "query_string": b"",
+        "headers": [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()],
+    }
+    response = {"body": b"", "headers_list": []}
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    async def send(message):
+        if message["type"] == "http.response.start":
+            response["status"] = message["status"]
+            response["headers_list"] = [
+                (k.decode(), v.decode()) for k, v in message.get("headers", [])
+            ]
+        elif message["type"] == "http.response.body":
+            response["body"] += message.get("body", b"")
+
+    await app(scope, receive, send)
+    response["headers"] = dict(response["headers_list"])
+    return response
+
+
+def _setup_db(monkeypatch, tmp_path):
+    monkeypatch.setattr(database, "DB_PATH", tmp_path / "test.db")
+    database.create_tables()
+
+
+def test_security_headers_present():
+    resp = asyncio.run(asgi_request(app, "POST", "/api/status"))
+    headers = resp["headers"]
+    assert headers["X-Content-Type-Options".lower()] == "nosniff"
+    assert headers["X-Frame-Options".lower()] == "DENY"
+    assert headers["Referrer-Policy".lower()] == "same-origin"
+    assert "Strict-Transport-Security".lower() in headers
+
+
+def test_cors_allows_configured_origin():
+    headers = {
+        "Origin": "https://fixhub.opotek.es",
+        "Access-Control-Request-Method": "POST",
+    }
+    resp = asyncio.run(asgi_request(app, "OPTIONS", "/api/status", headers=headers))
+    assert resp["status"] == 200
+    assert resp["headers"].get("access-control-allow-origin") == "https://fixhub.opotek.es"
+
+
+def test_cors_blocks_unconfigured_origin():
+    headers = {
+        "Origin": "https://evil.com",
+        "Access-Control-Request-Method": "POST",
+    }
+    resp = asyncio.run(asgi_request(app, "OPTIONS", "/api/status", headers=headers))
+    assert resp["status"] == 400
+
+
+def test_csrf_double_submit(monkeypatch, tmp_path):
+    _setup_db(monkeypatch, tmp_path)
+    login_body = json.dumps({"email": "demo@fixhub.es", "password": "demo123!"}).encode()
+    login = asyncio.run(
+        asgi_request(
+            app,
+            "POST",
+            "/api/auth/login",
+            headers={"content-type": "application/json"},
+            body=login_body,
+        )
+    )
+    cookies = SimpleCookie()
+    for name, value in login["headers_list"]:
+        if name.lower() == "set-cookie":
+            cookies.load(value)
+    csrf = cookies["csrf_token"].value
+    cookie_header = f"auth_token={cookies['auth_token'].value}; csrf_token={csrf}"
+
+    ok = asyncio.run(
+        asgi_request(
+            app,
+            "POST",
+            "/api/status",
+            headers={"cookie": cookie_header, "x-csrf-token": csrf},
+        )
+    )
+    assert ok["status"] == 200
+
+    bad = asyncio.run(
+        asgi_request(
+            app,
+            "POST",
+            "/api/status",
+            headers={"cookie": cookie_header, "x-csrf-token": "bad"},
+        )
+    )
+    assert bad["status"] == 403


### PR DESCRIPTION
## Summary
- restrict CORS to production and staging domains
- set security headers and add CSRF double-submit protection
- support auth tokens in cookies
- test CORS, security headers and CSRF flow

## Testing
- `pytest`
- `bandit -r app` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aed26297c48325927ed9caec5bdf57