### PR TITLE
Harden SQLite security and add backup utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Tradex Backend
+
+## SQLite Security
+
+- Database path defaults to `~/.tradex/users.db`. Override with `TRADEX_DB_PATH`.
+- File and WAL permissions are forced to `600`.
+- Demo users are not seeded when `TRADEX_ENV=production`.
+- Enable optional SQLCipher support with `TRADEX_USE_SQLCIPHER=1` and provide `TRADEX_DB_KEY`.
+- Use `scripts/db_backup.py` for backups and restores.
+  - `python scripts/db_backup.py backup /path/to/backup.db`
+  - `python scripts/db_backup.py restore /path/to/backup.db`
+
+For environments without SQLCipher, ensure disk-level encryption is enabled.

--- a/scripts/db_backup.py
+++ b/scripts/db_backup.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Utility for backing up and restoring the Tradex SQLite database."""
+
+import argparse
+import os
+import shutil
+import sqlite3
+from pathlib import Path
+
+DEFAULT_DB_PATH = Path(
+    os.getenv("TRADEX_DB_PATH", str(Path.home() / ".tradex" / "users.db"))
+)
+
+
+def backup_db(destination: str) -> None:
+    dest = Path(destination)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(DEFAULT_DB_PATH) as src, sqlite3.connect(dest) as dst:
+        src.backup(dst)
+    os.chmod(dest, 0o600)
+
+
+def restore_db(backup_file: str, destination: str | None = None) -> None:
+    dest = Path(destination) if destination else DEFAULT_DB_PATH
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(Path(backup_file), dest)
+    os.chmod(dest, 0o600)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Backup or restore the database")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    b = sub.add_parser("backup", help="Backup the database")
+    b.add_argument("destination", help="Destination backup file")
+
+    r = sub.add_parser("restore", help="Restore the database from a backup")
+    r.add_argument("backup_file", help="Path to the backup file")
+    r.add_argument("destination", nargs="?", help="Optional destination for restore")
+
+    args = parser.parse_args()
+
+    if args.command == "backup":
+        backup_db(args.destination)
+    elif args.command == "restore":
+        restore_db(args.backup_file, args.destination)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,8 +1,11 @@
 import sys, pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
 
+import os
 import pytest
 from fastapi import HTTPException
+
+os.environ.setdefault("SECRET_KEY", "testing")
 
 from app import auth, database
 from app.dependencies import get_current_user
@@ -20,7 +23,8 @@ def test_create_and_decode_access_token():
     assert decoded["sub"] == "user@example.com"
 
 
-def test_get_current_user_with_valid_token():
+def test_get_current_user_with_valid_token(tmp_path, monkeypatch):
+    monkeypatch.setattr(database, 'DB_PATH', tmp_path / 'test.db')
     database.create_tables()
     token = auth.create_access_token({"sub": "demo@fixhub.es"})
     user = get_current_user(token)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,42 +1,102 @@
-import sys, pathlib, sqlite3
+import os
+import sys
+import pathlib
+import sqlite3
+import stat
+
+os.environ.setdefault("SECRET_KEY", "testing")
+
 sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
 
 import pytest
 from app import database
+from scripts import db_backup
+
+
+def _setup(tmp_path, monkeypatch, env="development"):
+    monkeypatch.setenv("TRADEX_ENV", env)
+    db_file = tmp_path / "test.db"
+    monkeypatch.setattr(database, "DB_PATH", db_file)
+    monkeypatch.setenv("TRADEX_DB_PATH", str(db_file))
+    monkeypatch.setattr(db_backup, "DEFAULT_DB_PATH", db_file)
+    return db_file
 
 
 def test_create_tables_seeds_demo_users(tmp_path, monkeypatch):
-    monkeypatch.setattr(database, 'DB_PATH', tmp_path / 'test.db')
+    _setup(tmp_path, monkeypatch, env="development")
     database.create_tables()
-    user = database.get_user('demo@fixhub.es')
+    user = database.get_user("demo@fixhub.es")
     assert user is not None
-    assert user['username'] == 'demo@fixhub.es'
+    assert user["username"] == "demo@fixhub.es"
+
+
+def test_create_tables_no_demo_in_production(tmp_path, monkeypatch):
+    _setup(tmp_path, monkeypatch, env="production")
+    database.create_tables()
+    assert database.get_user("demo@fixhub.es") is None
 
 
 def test_get_all_users_returns_seeded_accounts(tmp_path, monkeypatch):
-    monkeypatch.setattr(database, 'DB_PATH', tmp_path / 'test.db')
+    _setup(tmp_path, monkeypatch, env="development")
     database.create_tables()
     users = database.get_all_users()
-    usernames = {u['username'] for u in users}
-    assert {'demo@fixhub.es', 'demo2@fixhub.es'} <= usernames
+    usernames = {u["username"] for u in users}
+    assert {"demo@fixhub.es", "demo2@fixhub.es"} <= usernames
 
 
 def test_increment_device_usage(tmp_path, monkeypatch):
-    monkeypatch.setattr(database, 'DB_PATH', tmp_path / 'test.db')
+    _setup(tmp_path, monkeypatch, env="development")
     database.create_tables()
-    database.increment_device_usage('demo@fixhub.es', 'device1')
-    database.increment_device_usage('demo@fixhub.es', 'device1')
-    usage = database.get_device_usage('demo@fixhub.es', 'device1')
-    assert usage['quote_count'] == 2
+    database.increment_device_usage("demo@fixhub.es", "device1")
+    database.increment_device_usage("demo@fixhub.es", "device1")
+    usage = database.get_device_usage("demo@fixhub.es", "device1")
+    assert usage["quote_count"] == 2
 
 
 def test_add_login_records_entry(tmp_path, monkeypatch):
-    monkeypatch.setattr(database, 'DB_PATH', tmp_path / 'test.db')
+    _setup(tmp_path, monkeypatch, env="development")
     database.create_tables()
-    database.add_login('demo@fixhub.es', 'deviceA')
+    database.add_login("demo@fixhub.es", "deviceA")
     conn = database.get_connection()
     cur = conn.cursor()
-    cur.execute('SELECT COUNT(*) FROM logins WHERE username=? AND device_id=?', ('demo@fixhub.es', 'deviceA'))
+    cur.execute(
+        "SELECT COUNT(*) FROM logins WHERE username=? AND device_id=?",
+        ("demo@fixhub.es", "deviceA"),
+    )
     count = cur.fetchone()[0]
     conn.close()
     assert count == 1
+
+
+def test_db_permissions(tmp_path, monkeypatch):
+    db_file = _setup(tmp_path, monkeypatch, env="development")
+    database.create_tables()
+    hold_conn = database.get_connection()
+    database.add_login("demo@fixhub.es", "permcheck")
+    wal_path = db_file.with_name("test.db-wal")
+    assert wal_path.exists()
+    db_mode = stat.S_IMODE(os.stat(db_file).st_mode)
+    wal_mode = stat.S_IMODE(os.stat(wal_path).st_mode)
+    hold_conn.close()
+    assert db_mode == 0o600
+    assert wal_mode == 0o600
+
+
+def test_backup_and_restore(tmp_path, monkeypatch):
+    db_file = _setup(tmp_path, monkeypatch, env="development")
+    database.create_tables()
+    conn = database.get_connection()
+    conn.execute(
+        "INSERT INTO users (username, hashed_password) VALUES (?, ?)",
+        ("alice", "pw"),
+    )
+    conn.commit()
+    conn.close()
+
+    backup_file = tmp_path / "backup.db"
+    db_backup.backup_db(str(backup_file))
+    os.remove(db_file)
+    db_backup.restore_db(str(backup_file), str(db_file))
+
+    user = database.get_user("alice")
+    assert user is not None

--- a/tests/test_quote.py
+++ b/tests/test_quote.py
@@ -1,4 +1,5 @@
-import sys, pathlib, types, json
+import sys, pathlib, types, json, os
+os.environ.setdefault("SECRET_KEY", "testing")
 sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
 
 # Stub external modules not available in test environment


### PR DESCRIPTION
## Summary
- enforce restrictive permissions and WAL journaling for SQLite with optional SQLCipher support
- disable demo user seeds in production and document DB hardening
- add `db_backup.py` script and tests for backup/restore and file permissions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aed28cc26c8325a455ab960f853b9f