### PR TITLE
feat: add quote PDF metadata and checksum

### DIFF
--- a/app/quote.py
+++ b/app/quote.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException, Header, Response, Depends
 from pydantic import BaseModel, Field
 from typing import List, Optional
 from datetime import datetime, timedelta
-import os, json
+import os, json, hashlib
 from openai import OpenAI
 from jinja2 import Environment, BaseLoader
 from weasyprint import HTML
@@ -63,6 +63,7 @@ class Quote(BaseModel):
     terms: Optional[str] = ""
     note: Optional[str] = ""
     raw_text: Optional[str] = ""
+    demo: bool = False
 
 # --- Memoria en RAM (demo). Cambiar a DB en prod. ---
 DB: dict[str, Quote] = {}
@@ -149,6 +150,7 @@ def generate(
     tax_total = round(subtotal * tax_rate / 100, 2)
     total = round(subtotal + tax_total, 2)
 
+    is_demo = current_user in {"demo@fixhub.es", "demo2@fixhub.es"}
     quote = Quote(
         quote_id=f"q_{len(DB)+1:05d}",
         currency=data.get("currency","EUR"),
@@ -160,7 +162,8 @@ def generate(
         schedule=q.when,
         terms=data.get("terms",""),
         note=data.get("note",""),
-        raw_text=data.get("raw_text","")
+        raw_text=data.get("raw_text",""),
+        demo=is_demo
     )
     DB[quote.quote_id] = quote
     return quote
@@ -235,6 +238,7 @@ TPL = Environment(loader=BaseLoader()).from_string("""
 <body>
   <h1>Presupuesto {{quote.quote_id}}</h1>
   <div class="muted">Programado: {{quote.schedule or "Sin fecha"}}</div>
+  {% if demo %}<div style="position:fixed; top:40%; left:20%; font-size:72px; color:rgba(200,0,0,0.2); transform:rotate(-30deg);">DEMO</div>{% endif %}
 
   <table>
     <thead><tr><th>Concepto</th><th>Ud</th><th>Cant.</th><th>Precio</th><th>Importe</th></tr></thead>
@@ -258,20 +262,55 @@ TPL = Environment(loader=BaseLoader()).from_string("""
 
   <p class="muted">{{quote.terms}}</p>
   {% if quote.note %}<p class="muted">Nota: {{quote.note}}</p>{% endif %}
+  <p class="muted">{{seal}}</p>
 </body>
 </html>
 """)
 
-@router.post("/api/quotes/{quote_id}/pdf")
+@router.get("/api/quotes/{quote_id}/pdf")
 def pdf(quote_id: str, x_api_key: Optional[str] = Header(None)):
     check_api_key(x_api_key)
     if quote_id not in DB:
         raise HTTPException(404, "Quote not found")
     q = DB[quote_id]
-
     forward_to_openai("Genera un PDF para este presupuesto", q.model_dump())
 
-    html = TPL.render(quote=q.model_dump())
+    # Metadatos y checksum
+    prompt_version = "unknown"
+    tarifa = None
+    try:
+        with open(PROMPT_FILE, "r", encoding="utf-8") as f:
+            content = f.read()
+        prompt_version = hashlib.sha256(content.encode("utf-8")).hexdigest()[:8]
+        scope: dict[str, object] = {}
+        try:
+            exec(content, {}, scope)
+        except Exception:
+            pass
+        tarifa = scope.get("tarifa_hora_eur")
+    except FileNotFoundError:
+        pass
+
+    data_for_checksum = {
+        "quote": q.model_dump(),
+        "prompt_version": prompt_version,
+        "iva": q.tax_rate,
+        "tarifa": tarifa,
+        "demo": q.demo,
+    }
+    checksum = hashlib.sha256(
+        json.dumps(data_for_checksum, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+
+    seal_parts = [f"Prompt {prompt_version}", f"IVA {q.tax_rate}%"]
+    if tarifa is not None:
+        seal_parts.append(f"Tarifa {tarifa}")
+    seal_parts.append(f"Checksum {checksum}")
+    if q.demo:
+        seal_parts.append("DEMO")
+    seal = " | ".join(seal_parts)
+
+    html = TPL.render(quote=q.model_dump(), seal=seal, demo=q.demo)
     pdf_bytes = HTML(string=html).write_pdf()  # Docs: WeasyPrint
     # Opción B: enviar al webhook de Fixhub si está configurado
     webhook = os.getenv("FIXHUB_WEBHOOK_URL", "").strip()
@@ -281,5 +320,11 @@ def pdf(quote_id: str, x_api_key: Optional[str] = Header(None)):
         return {"status":"sent", "bytes": len(pdf_bytes)}
 
     # Opción A: devolver binario al frontend
-    return Response(content=pdf_bytes, media_type="application/pdf",
-                    headers={"Content-Disposition": f'attachment; filename="{quote_id}.pdf"'})
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={
+            "Content-Disposition": f'attachment; filename="{quote_id}.pdf"',
+            "X-Checksum": checksum,
+        },
+    )

--- a/tests/test_quote.py
+++ b/tests/test_quote.py
@@ -62,7 +62,7 @@ def setup_quote(monkeypatch, tmp_path):
     monkeypatch.setattr(quote, 'forward_to_openai', fake_forward)
     monkeypatch.setattr(quote, 'EXPECTED_API_KEY', None)
     prompt_file = tmp_path / 'prompt.py'
-    prompt_file.write_text('custom_msg = "hi"')
+    prompt_file.write_text('custom_msg = "hi"\ntarifa_hora_eur = 60')
     monkeypatch.setattr(quote, 'PROMPT_FILE', str(prompt_file))
 
 
@@ -92,3 +92,17 @@ def test_pdf_generation(monkeypatch, tmp_path):
     res = quote.pdf('q_00001', x_api_key=None)
     assert res.media_type == 'application/pdf'
     assert res.body == b'pdf'
+    assert 'X-Checksum' in res.headers
+
+
+def test_pdf_checksum_changes(monkeypatch, tmp_path):
+    setup_quote(monkeypatch, tmp_path)
+    req = quote.QuoteRequest(client=quote.Client(name='John'), description='desc')
+    quote.generate(req, x_api_key=None, device_id='dev1', current_user='user@example.com')
+    res1 = quote.pdf('q_00001', x_api_key=None)
+    checksum1 = res1.headers['X-Checksum']
+    body = quote.PatchBody(items=[quote.PatchItem(index=0, qty=2)])
+    quote.patch_quote('q_00001', body, x_api_key=None)
+    res2 = quote.pdf('q_00001', x_api_key=None)
+    checksum2 = res2.headers['X-Checksum']
+    assert checksum1 != checksum2


### PR DESCRIPTION
## Summary
- stamp quote PDFs with prompt version, tax info and checksum
- flag demo quotes and expose PDF download via GET
- test PDF checksum changes when quote data is modified

## Testing
- `SECRET_KEY=test pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aed2b7f65483259a3576cadf3d7058