### PR TITLE
feat: enforce secrets and add dependency scanning pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        env:
+          SECRET_KEY: test-secret-key
+        run: |
+          pytest
+
+      - name: Run SCA scan
+        run: |
+          pip install pip-audit
+          pip-audit -r requirements.txt -f json -o sca-report.json
+
+      - name: Generate SBOM
+        run: |
+          pip install cyclonedx-bom
+          cyclonedx-py -r requirements.txt -o sbom.json
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-artifacts
+          path: |
+            sca-report.json
+            sbom.json

--- a/app/main.py
+++ b/app/main.py
@@ -16,6 +16,34 @@ from pydantic import BaseModel
 
 
 # ---------------------------------------------------------------------------
+# Required secrets
+# ---------------------------------------------------------------------------
+# List of environment variables that must be present for the application to
+# start. Additional secrets can be added here as needed.
+REQUIRED_ENV_VARS = ["SECRET_KEY"]
+
+
+def validate_required_env_vars() -> None:
+    """Ensure that all required environment variables are defined.
+
+    The application should fail fast during start-up if any critical
+    configuration is missing. This helps surface misconfigurations early in
+    the deployment process and avoids running with insecure defaults.
+    """
+
+    missing = [var for var in REQUIRED_ENV_VARS if not os.getenv(var)]
+    if missing:
+        missing_vars = ", ".join(missing)
+        raise RuntimeError(
+            f"Missing required environment variables: {missing_vars}"
+        )
+
+
+# Validate secrets before continuing with application setup
+validate_required_env_vars()
+
+
+# ---------------------------------------------------------------------------
 # Feature flags
 # ---------------------------------------------------------------------------
 ENABLE_USER_AUTH = os.getenv("ENABLE_USER_AUTH", "1") == "1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-fastapi
-uvicorn
+fastapi==0.116.1
+uvicorn==0.35.0
 passlib[bcrypt]==1.7.4
-bcrypt<4
-python-jose
+bcrypt==3.2.2
+python-jose==3.5.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+
+# Ensure that the application has a SECRET_KEY during tests. In production this
+# must be set through a proper secret management mechanism.
+os.environ.setdefault("SECRET_KEY", "test-secret-key")


### PR DESCRIPTION
## Summary
- validate required SECRET_KEY before application startup
- pin dependency versions
- add CI workflow for tests, SCA scan, and SBOM generation

## Testing
- `pytest`
- `pip install pip-audit` *(fails: Could not find a version that satisfies the requirement pip-audit)*
- `pip install cyclonedx-bom` *(fails: Could not find a version that satisfies the requirement cyclonedx-bom)*

------
https://chatgpt.com/codex/tasks/task_e_68aed2ccc7408325a41c1b1da4eef350