### PR TITLE
Expose database and add status endpoint

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -53,7 +53,7 @@ def create_tables() -> None:
         CREATE TABLE IF NOT EXISTS users (
             username TEXT PRIMARY KEY,
             hashed_password TEXT NOT NULL,
-            role TEXT NOT NULL
+            role TEXT NOT NULL DEFAULT 'User'
         )
         """
     )
@@ -97,16 +97,16 @@ def create_tables() -> None:
 
     if os.getenv("TRADEX_ENV") != "production":
         demo_users = [
-        ("demo@fixhub.es", "demo123!", "Owner"),
-        ("demo2@fixhub.es", "demo456!", "User"),
-    ]
-    for username, password, role in demo_users:
-        cur.execute("SELECT 1 FROM users WHERE username = ?", (username,))
-        if cur.fetchone() is None:
-            cur.execute(
-                "INSERT INTO users (username, hashed_password, role) VALUES (?, ?, ?)",
-                (username, get_password_hash(password), role),
-            )
+            ("demo@fixhub.es", "demo123!", "Owner"),
+            ("demo2@fixhub.es", "demo456!", "User"),
+        ]
+        for username, password, role in demo_users:
+            cur.execute("SELECT 1 FROM users WHERE username = ?", (username,))
+            if cur.fetchone() is None:
+                cur.execute(
+                    "INSERT INTO users (username, hashed_password, role) VALUES (?, ?, ?)",
+                    (username, get_password_hash(password), role),
+                )
 
 
     conn.commit()


### PR DESCRIPTION
## Summary
- Import database module unconditionally so tests can access `app.main.database`
- Add `/api/status` endpoint and authenticated `/api/health-status` check
- Harden login IP handling and fix database seeding/role defaults
- Simplify quote generation for direct calls and handle PDF timeouts

## Testing
- `pytest tests/test_database.py::test_create_tables_no_demo_in_production tests/test_database.py::test_backup_and_restore tests/test_health.py::test_health_requires_auth tests/test_health.py::test_health_with_owner_role tests/test_health.py::test_health_forbidden_role -q`
- `pytest tests/test_quote.py::test_pdf_timeout -q`
- `pytest -q` *(fails: test_audit_logging)*

------
https://chatgpt.com/codex/tasks/task_e_68b05a20a4d08325a1aa991d482176af