### PR TITLE
feat(auth): rotate refresh tokens with revocation

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -1,14 +1,20 @@
-from datetime import datetime, timedelta
-from typing import Optional
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Optional
+from uuid import uuid4
 
 from jose import JWTError, jwt
 from passlib.context import CryptContext
 
 SECRET_KEY = "change-me"  # In production, load from environment
 ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 30
+ACCESS_TOKEN_EXPIRE_MINUTES = 15
+REFRESH_TOKEN_EXPIRE_DAYS = 14
+CLOCK_SKEW_SECONDS = 60
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+# In-memory revocation list keyed by token jti
+_revoked_tokens: Dict[str, datetime] = {}
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
@@ -19,15 +25,65 @@ def get_password_hash(password: str) -> str:
     return pwd_context.hash(password)
 
 
-def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+def _create_token(data: dict, expires_delta: timedelta, token_type: str) -> str:
     to_encode = data.copy()
-    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
-    to_encode.update({"exp": expire})
+    expire = datetime.now(timezone.utc) + expires_delta
+    to_encode.update({"exp": expire, "type": token_type, "jti": str(uuid4())})
     return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
 
 
-def decode_access_token(token: str) -> Optional[dict]:
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    return _create_token(
+        data,
+        expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES),
+        "access",
+    )
+
+
+def create_refresh_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    return _create_token(
+        data,
+        expires_delta or timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS),
+        "refresh",
+    )
+
+
+def _is_token_revoked(jti: str) -> bool:
+    exp = _revoked_tokens.get(jti)
+    if exp is None:
+        return False
+    if exp < datetime.now(timezone.utc):
+        # Cleanup expired entries
+        del _revoked_tokens[jti]
+        return False
+    return True
+
+
+def revoke_token(jti: str, exp: int) -> None:
+    _revoked_tokens[jti] = datetime.fromtimestamp(exp, tz=timezone.utc)
+
+
+def _decode_token(token: str, token_type: str) -> Optional[dict]:
     try:
-        return jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        payload = jwt.decode(
+            token,
+            SECRET_KEY,
+            algorithms=[ALGORITHM],
+            options={"leeway": CLOCK_SKEW_SECONDS},
+        )
     except JWTError:
         return None
+    if payload.get("type") != token_type:
+        return None
+    jti = payload.get("jti")
+    if jti is None or _is_token_revoked(jti):
+        return None
+    return payload
+
+
+def decode_access_token(token: str) -> Optional[dict]:
+    return _decode_token(token, "access")
+
+
+def decode_refresh_token(token: str) -> Optional[dict]:
+    return _decode_token(token, "refresh")

--- a/tests/test_auth_session.py
+++ b/tests/test_auth_session.py
@@ -1,0 +1,52 @@
+import pytest
+import sys
+from pathlib import Path
+from fastapi import HTTPException
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import auth, database, main
+from app.main import LoginRequest, RefreshRequest
+
+
+def setup_module(module):
+    if database.DB_PATH.exists():
+        database.DB_PATH.unlink()
+    database.create_tables()
+    conn = database.get_connection()
+    cur = conn.cursor()
+    password_hash = auth.get_password_hash("secret")
+    cur.execute(
+        "INSERT INTO users (org_id, username, hashed_password) VALUES (?, ?, ?)",
+        ("org1", "alice", password_hash),
+    )
+    conn.commit()
+    conn.close()
+    auth._revoked_tokens.clear()
+
+
+def test_refresh_token_rotation_rejects_reuse():
+    login_payload = LoginRequest(org_id="org1", username="alice", password="secret", device_id="dev1")
+    tokens = main.login(login_payload)
+    refresh_req = RefreshRequest(refresh_token=tokens.refresh_token)
+    new_tokens = main.refresh(refresh_req)
+    assert new_tokens.access_token and new_tokens.refresh_token
+    # Reusing old refresh token should now fail
+    with pytest.raises(HTTPException) as exc:
+        main.refresh(refresh_req)
+    assert exc.value.status_code == 401
+
+
+def test_logout_revokes_tokens():
+    login_payload = LoginRequest(org_id="org1", username="alice", password="secret", device_id="dev1")
+    tokens = main.login(login_payload)
+    refresh_req = RefreshRequest(refresh_token=tokens.refresh_token)
+    main.logout(refresh_req, tokens.access_token)
+    # Access token should be revoked
+    with pytest.raises(HTTPException) as exc:
+        main.get_current_user(tokens.access_token)
+    assert exc.value.status_code == 401
+    # Refresh token should also be revoked
+    with pytest.raises(HTTPException) as exc:
+        main.refresh(refresh_req)
+    assert exc.value.status_code == 401

--- a/tests/test_tenancy.py
+++ b/tests/test_tenancy.py
@@ -30,6 +30,7 @@ def test_login_success_and_wrong_org_rejected():
     )
     token_model = main.login(payload)
     assert token_model.access_token
+    assert token_model.refresh_token
 
     payload_bad = LoginRequest(
         org_id="org2", username="alice", password="secret", device_id="dev1"


### PR DESCRIPTION
## Summary
- issue short-lived access tokens and rotating refresh tokens
- revoke tokens on reuse or logout with server-side revocation list
- add tests for refresh rotation and logout revocation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b169d0a97c83258d2776b72a9b5ce7